### PR TITLE
Support Logging to Grafana Loki

### DIFF
--- a/currentmonitor/lantern-currentmonitor/pom.xml
+++ b/currentmonitor/lantern-currentmonitor/pom.xml
@@ -13,6 +13,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.github.loki4j</groupId>
+			<artifactId>loki-logback-appender</artifactId>
+			<version>1.5.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.29</version>

--- a/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/LoggerStartupListener.java
+++ b/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/LoggerStartupListener.java
@@ -1,0 +1,66 @@
+package com.lanternsoftware.currentmonitor;
+
+import com.lanternsoftware.util.ResourceLoader;
+import com.lanternsoftware.util.dao.DaoSerializer;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.spi.LifeCycle;
+
+public class LoggerStartupListener extends ContextAwareBase implements LoggerContextListener, LifeCycle {
+    
+	private static final String WORKING_DIR = "/opt/currentmonitor/";
+
+    private boolean started = false;
+
+    @Override
+    public void start() {
+        if (started) return;
+
+		MonitorConfig config = DaoSerializer.parse(ResourceLoader.loadFileAsString(WORKING_DIR + "config.json"), MonitorConfig.class);
+		if (config == null) {
+			config = new MonitorConfig();
+			ResourceLoader.writeFile(WORKING_DIR + "config.json", DaoSerializer.toJson(config));
+		}
+
+        Context context = getContext();
+
+        context.putProperty("LOKI_URL", config.getLokiUrl());
+
+        started = true;
+    }
+
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+
+    @Override
+    public boolean isResetResistant() {
+        return true;
+    }
+
+    @Override
+    public void onStart(LoggerContext context) {
+    }
+
+    @Override
+    public void onReset(LoggerContext context) {
+    }
+
+    @Override
+    public void onStop(LoggerContext context) {
+    }
+
+    @Override
+    public void onLevelChange(Logger arg0, Level arg1) {
+    }
+}

--- a/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/MonitorApp.java
+++ b/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/MonitorApp.java
@@ -219,6 +219,7 @@ public class MonitorApp {
 			config = new MonitorConfig();
 			ResourceLoader.writeFile(WORKING_DIR + "config.json", DaoSerializer.toJson(config));
 		}
+		LOG.info("Configuration loaded from: " + WORKING_DIR + "config.json");
 		pool = HttpPool.builder().withValidateSSLCertificates(!config.isAcceptSelfSignedCertificates()).build();
 		if (NullUtils.isNotEmpty(config.getHost()))
 			host = NullUtils.terminateWith(config.getHost(), "/");

--- a/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/MonitorConfig.java
+++ b/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/MonitorConfig.java
@@ -1,6 +1,5 @@
 package com.lanternsoftware.currentmonitor;
 
-
 import com.lanternsoftware.datamodel.currentmonitor.Breaker;
 import com.lanternsoftware.util.NullUtils;
 import com.lanternsoftware.util.dao.annotations.DBSerializable;
@@ -27,6 +26,7 @@ public class MonitorConfig {
     private double mqttPortCalibrationFactor;
     private int mqttFrequency;
     private List<Breaker> mqttBreakers;
+    private String lokiUrl;
 
     public MonitorConfig() {
     }
@@ -188,5 +188,13 @@ public class MonitorConfig {
 
     public void setMqttBreakers(List<Breaker> _mqttBreakers) {
         mqttBreakers = _mqttBreakers;
+    }
+
+    public String getLokiUrl() {
+        return NullUtils.isEmpty(lokiUrl) ? "http://127.0.0.1:3100" : lokiUrl;
+    }
+
+    public void setLokiUrl(String _lokiUrl) {
+        lokiUrl = _lokiUrl;
     }
 }

--- a/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/dao/MonitorConfigSerializer.java
+++ b/currentmonitor/lantern-currentmonitor/src/main/java/com/lanternsoftware/currentmonitor/dao/MonitorConfigSerializer.java
@@ -44,6 +44,7 @@ public class MonitorConfigSerializer extends AbstractDaoSerializer<MonitorConfig
 		d.put("mqtt_port_calibration_factor", _o.getMqttPortCalibrationFactor());
 		d.put("mqtt_frequency", _o.getMqttFrequency());
 		d.put("mqtt_breakers", DaoSerializer.toDaoEntities(_o.getMqttBreakers(), DaoProxyType.MONGO));
+		d.put("loki_url", _o.getLokiUrl());
 		return d;
 	}
 
@@ -69,6 +70,7 @@ public class MonitorConfigSerializer extends AbstractDaoSerializer<MonitorConfig
 		o.setMqttPortCalibrationFactor(DaoSerializer.getDouble(_d, "mqtt_port_calibration_factor"));
 		o.setMqttFrequency(DaoSerializer.getInteger(_d, "mqtt_frequency"));
 		o.setMqttBreakers(DaoSerializer.getList(_d, "mqtt_breakers", Breaker.class));
+		o.setLokiUrl(DaoSerializer.getString(_d, "loki_url"));
 		return o;
 	}
 }

--- a/currentmonitor/lantern-currentmonitor/src/main/resources/logback.xml
+++ b/currentmonitor/lantern-currentmonitor/src/main/resources/logback.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <contextListener class="com.lanternsoftware.currentmonitor.LoggerStartupListener"/>
+
     <property name="log.pattern" value="%date %-5level %logger{0} - %message%n"/>
-    <property name="loki.baseurl" value="http://10.0.10.23:3100"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/opt/currentmonitor/log/log.txt</file>
@@ -17,7 +18,7 @@
 
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>${loki.baseurl}/loki/api/v1/push</url>
+            <url>${LOKI_URL}/loki/api/v1/push</url>
         </http>
         <format>
             <label>

--- a/currentmonitor/lantern-currentmonitor/src/main/resources/logback.xml
+++ b/currentmonitor/lantern-currentmonitor/src/main/resources/logback.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <property name="log.pattern" value="%date %-5level %logger{0} - %message%n"/>
+    <property name="loki.baseurl" value="http://10.0.10.23:3100"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/opt/currentmonitor/log/log.txt</file>
@@ -14,10 +15,27 @@
         </encoder>
     </appender>
 
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${loki.baseurl}/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=currentmonitor,host=${HOSTNAME}</pattern>
+            </label>
+            <message>
+                <pattern>%-5level [%.5(${HOSTNAME})] %.10thread %logger{20} | %msg %ex</pattern>
+            </message>
+        </format>
+    </appender>
+
     <logger name="com.lanternsoftware" level="INFO"/>
     <logger name="com.pi4j" level="INFO"/>
 
     <root level="OFF">
         <appender-ref ref="FILE"/>
+    </root>
+    <root level="DEBUG">
+        <appender-ref ref="LOKI" />
     </root>
 </configuration>


### PR DESCRIPTION
This change adds support for using Grafana Loki as a logging target.

To do this, 1 new setting is added to the config: "loki_url" where the value should look something like "http://127.0.0.1:3100", pointing to the instance of Loki.