### PR TITLE
reduce cpu usage substantially by adding sleeps to two main loops in pi service

### DIFF
--- a/java/lantern-powermonitor/src/main/java/com/lanternsoftware/powermonitor/MonitorApp.java
+++ b/java/lantern-powermonitor/src/main/java/com/lanternsoftware/powermonitor/MonitorApp.java
@@ -409,6 +409,7 @@ public class MonitorApp {
 						ConcurrencyUtils.sleep(1000 - duration);
 					}
 					lastPost = now;
+					ConcurrencyUtils.sleep(10);
 				}
 			}
 			catch (Throwable t) {

--- a/java/lantern-powermonitor/src/main/java/com/lanternsoftware/powermonitor/PowerMonitor.java
+++ b/java/lantern-powermonitor/src/main/java/com/lanternsoftware/powermonitor/PowerMonitor.java
@@ -361,6 +361,7 @@ public class PowerMonitor {
 						if (hubSample != null)
 							listener.onSampleEvent(hubSample);
 					});
+					ConcurrencyUtils.sleep(250);
 				}
 			}
 			catch (Throwable t) {


### PR DESCRIPTION
please confirm that these sleeps do not affect the operation of the service. i think 4 times per second is plenty for monitoring, perhaps it can be made longer.

these loops were running at full tilt with no limits, causing 100% usage on a single core.